### PR TITLE
Fix superstructures in _SOUR yaml

### DIFF
--- a/structure/extension/_SOUR
+++ b/structure/extension/_SOUR
@@ -29,5 +29,6 @@ substructures:
   "https://gedcom.io/terms/v7/SOUR-EVEN": "{0:1}"
 
 superstructures:
-  "https://gedcom.io/terms/v7/PAGE": "{0:1}"
+  "https://gedcom.io/terms/v7/PAGE": "{0:M}"
+  "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
 ...


### PR DESCRIPTION
`_SOUR` can occur {0:M} times in a `SOURCE_CITATION` or `SOURCE_RECORD`, per https://github.com/dthaler/gedcom-citations/blob/main/source-derivation-extension.md

The YAML wasn't updated to match the updated markdown before they were merged.