### PR TITLE
add contact to yaml-schma.yaml

### DIFF
--- a/registry_tools/yaml-schema.yaml
+++ b/registry_tools/yaml-schema.yaml
@@ -73,6 +73,8 @@ properties:
     "$ref": "#/definitions/card"
   subsumes:
     "$ref": "#/definitions/uris"
+  contact:
+    type: string
   
 additionalProperties: false
 


### PR DESCRIPTION
Add `contact` to the schema to align with https://github.com/FamilySearch/GEDCOM.io/pull/150

The same change as https://github.com/FamilySearch/GEDCOM.io/pull/158 but to a different repo, as the schema is stored in both places