### PR TITLE
Validate registered YAML files against schema

### DIFF
--- a/.github/workflows/validate-yaml.yml
+++ b/.github/workflows/validate-yaml.yml
@@ -21,6 +21,22 @@ jobs:
     steps:
       - name: Checkout GEDCOM.io
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       - name: Validate YAML
-        run: yamllint . .github .github/workflows calendar/standard data-type/standard enumeration/standard enumeration-set/standard month/standard structure/extension structure/standard uri/exid-types
+        run: yamllint .
+ 
+      - name: Validate YAML against schema
+        working-directory: ${{github.workspace}}/registry_tools
+        run: |
+          find .. -type f -name "*.yaml" -not -path "../registry_tools/*" -exec dirname {} \; | sort -u | while read -r dir; do
+            yaml_files=("$dir"/*.yaml)
+            if [ "${#yaml_files[@]}" -gt 0 ]; then
+              echo Checking directory $dir
+              python3 validator.py "${yaml_files[@]}"
+              if [ $? -ne 0 ]; then
+                exit 1
+              fi
+            fi
+          done

--- a/registry_tools/validator.py
+++ b/registry_tools/validator.py
@@ -47,4 +47,5 @@ if ok != count:
   print("="*30+'\n')
 print("YAML files checked:",count)
 print("YAML files passed:",ok)
-
+if ok != count:
+  sys.exit(1)


### PR DESCRIPTION
Validate registered YAML files against schema as part of a github CI/CD run

It turns out that "yamllint ." is indeed recursive as can be seen by expanding the "Validate YAML" output at https://github.com/FamilySearch/GEDCOM-registries/actions/runs/8913148721/job/24478068214

Fixes #37