### PR TITLE
Don't warn about use of "on" as a YAML key

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -7,3 +7,5 @@ extends: default
 rules:
   line-length: disable
   trailing-spaces: disable
+  truthy:
+    check-keys: false


### PR DESCRIPTION
Per documentation at
https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy

This PR fixes warnings generated during github CI/CD in the validate-yaml workflow.