### PR TITLE
Add data from exid-types.json to the exid types registry

### DIFF
--- a/uri/exid-types/AFN.yaml
+++ b/uri/exid-types/AFN.yaml
@@ -28,6 +28,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FamilySearch
 
-documentation: https://gedcom.io/migrate/#afn-rfn-rin
+documentation:
+  - https://gedcom.io/migrate/#afn-rfn-rin
 
 ...

--- a/uri/exid-types/AFN.yaml
+++ b/uri/exid-types/AFN.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: AFN
+label: 'Ancestral File Number'
 
 lang: en
 

--- a/uri/exid-types/AFN.yaml
+++ b/uri/exid-types/AFN.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+label: AFN
+
 lang: en
 
 type: uri
@@ -21,5 +23,11 @@ specification:
     every record that was published in Ancestral File.
     
     See https://www.familysearch.org/wiki/en/Ancestral_File for more.
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+documentation: https://gedcom.io/migrate/#afn-rfn-rin
 
 ...

--- a/uri/exid-types/BillionGraves-CemeteryId.yaml
+++ b/uri/exid-types/BillionGraves-CemeteryId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: BillionGraves.com
 
-documentation: https://billiongraves.com/search/cemetery
+documentation:
+  - https://billiongraves.com/search/cemetery
 
 ...

--- a/uri/exid-types/BillionGraves-CemeteryId.yaml
+++ b/uri/exid-types/BillionGraves-CemeteryId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: BillionGraves Cemetery ID
+
+lang: en
+
+type: uri
+
+uri: https://www.billiongraves.com/cemetery/name/
+
+specification:
+  - BillionGraves Cemetery ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: BillionGraves.com
+
+documentation: https://billiongraves.com/search/cemetery
+
+...

--- a/uri/exid-types/BillionGraves-CemeteryId.yaml
+++ b/uri/exid-types/BillionGraves-CemeteryId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: BillionGraves Cemetery ID
+label: 'BillionGraves Cemetery ID'
 
 lang: en
 

--- a/uri/exid-types/BillionGraves-GraveId.yaml
+++ b/uri/exid-types/BillionGraves-GraveId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: BillionGraves Grave ID
+label: 'BillionGraves Grave ID'
 
 lang: en
 

--- a/uri/exid-types/BillionGraves-GraveId.yaml
+++ b/uri/exid-types/BillionGraves-GraveId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: BillionGraves.com
 
-documentation: https://billiongraves.com/search
+documentation:
+  - https://billiongraves.com/search
 
 ...

--- a/uri/exid-types/BillionGraves-GraveId.yaml
+++ b/uri/exid-types/BillionGraves-GraveId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: BillionGraves Grave ID
+
+lang: en
+
+type: uri
+
+uri: https://www.billiongraves.com/grave/name/
+
+specification:
+  - BillionGraves Grave ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: BillionGraves.com
+
+documentation: https://billiongraves.com/search
+
+...

--- a/uri/exid-types/FamilySearch-MemoryId.yaml
+++ b/uri/exid-types/FamilySearch-MemoryId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FamilySearch Memory ID
+label: 'FamilySearch Memory ID'
 
 lang: en
 

--- a/uri/exid-types/FamilySearch-MemoryId.yaml
+++ b/uri/exid-types/FamilySearch-MemoryId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FamilySearch Memory ID
+
+lang: en
+
+type: uri
+
+uri: https://gedcom.io/exid-type/FamilySearch-MemoryId
+
+specification:
+  - FamilySearch Memory ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+documentation: https://gedcom.io/exid-type/FamilySearch-MemoryId
+
+...

--- a/uri/exid-types/FamilySearch-MemoryId.yaml
+++ b/uri/exid-types/FamilySearch-MemoryId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FamilySearch
 
-documentation: https://gedcom.io/exid-type/FamilySearch-MemoryId
+documentation:
+  - https://gedcom.io/exid-type/FamilySearch-MemoryId
 
 ...

--- a/uri/exid-types/FamilySearch-PersonId.yaml
+++ b/uri/exid-types/FamilySearch-PersonId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FamilySearch Person ID
+
+lang: en
+
+type: uri
+
+uri: https://gedcom.io/exid-type/FamilySearch-PersonId
+
+specification:
+  - FamilySearch Person ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+documentation: https://gedcom.io/exid-type/FamilySearch-PersonId
+
+...

--- a/uri/exid-types/FamilySearch-PersonId.yaml
+++ b/uri/exid-types/FamilySearch-PersonId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FamilySearch
 
-documentation: https://gedcom.io/exid-type/FamilySearch-PersonId
+documentation:
+  - https://gedcom.io/exid-type/FamilySearch-PersonId
 
 ...

--- a/uri/exid-types/FamilySearch-PersonId.yaml
+++ b/uri/exid-types/FamilySearch-PersonId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FamilySearch Person ID
+label: 'FamilySearch Person ID'
 
 lang: en
 

--- a/uri/exid-types/FamilySearch-PlaceId.yaml
+++ b/uri/exid-types/FamilySearch-PlaceId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FamilySearch
 
-documentation: https://gedcom.io/exid-type/FamilySearch-PlaceId
+documentation:
+  - https://gedcom.io/exid-type/FamilySearch-PlaceId
 
 ...

--- a/uri/exid-types/FamilySearch-PlaceId.yaml
+++ b/uri/exid-types/FamilySearch-PlaceId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FamilySearch Place ID
+label: 'FamilySearch Place ID'
 
 lang: en
 

--- a/uri/exid-types/FamilySearch-PlaceId.yaml
+++ b/uri/exid-types/FamilySearch-PlaceId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FamilySearch Place ID
+
+lang: en
+
+type: uri
+
+uri: https://gedcom.io/exid-type/FamilySearch-PlaceId
+
+specification:
+  - FamilySearch Place ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+documentation: https://gedcom.io/exid-type/FamilySearch-PlaceId
+
+...

--- a/uri/exid-types/FamilySearch-SourceDescriptionId.yaml
+++ b/uri/exid-types/FamilySearch-SourceDescriptionId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FamilySearch
 
-documentation: https://gedcom.io/exid-type/FamilySearch-SourceDescriptionId
+documentation:
+  - https://gedcom.io/exid-type/FamilySearch-SourceDescriptionId
 
 ...

--- a/uri/exid-types/FamilySearch-SourceDescriptionId.yaml
+++ b/uri/exid-types/FamilySearch-SourceDescriptionId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FamilySearch Source Description ID
+
+lang: en
+
+type: uri
+
+uri: https://gedcom.io/exid-type/FamilySearch-SourceDescriptionId
+
+specification:
+  - FamilySearch Source Description ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+documentation: https://gedcom.io/exid-type/FamilySearch-SourceDescriptionId
+
+...

--- a/uri/exid-types/FamilySearch-SourceDescriptionId.yaml
+++ b/uri/exid-types/FamilySearch-SourceDescriptionId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FamilySearch Source Description ID
+label: 'FamilySearch Source Description ID'
 
 lang: en
 

--- a/uri/exid-types/FamilySearch-UserId.yaml
+++ b/uri/exid-types/FamilySearch-UserId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FamilySearch
 
-documentation: https://gedcom.io/exid-type/FamilySearch-UserId
+documentation:
+  - https://gedcom.io/exid-type/FamilySearch-UserId
 
 ...

--- a/uri/exid-types/FamilySearch-UserId.yaml
+++ b/uri/exid-types/FamilySearch-UserId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FamilySearch User ID
+label: 'FamilySearch User ID'
 
 lang: en
 

--- a/uri/exid-types/FamilySearch-UserId.yaml
+++ b/uri/exid-types/FamilySearch-UserId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FamilySearch User ID
+
+lang: en
+
+type: uri
+
+uri: https://gedcom.io/exid-type/FamilySearch-UserId
+
+specification:
+  - FamilySearch User ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+documentation: https://gedcom.io/exid-type/FamilySearch-UserId
+
+...

--- a/uri/exid-types/FindAGrave-CemeteryId.yaml
+++ b/uri/exid-types/FindAGrave-CemeteryId.yaml
@@ -6,7 +6,7 @@ lang: en
 
 type: uri
 
-uri: https://www.findagrave.com/cemetery
+uri: https://www.findagrave.com/cemetery/
 
 specification:
   - FindAGrave Cemetery ID

--- a/uri/exid-types/FindAGrave-CemeteryId.yaml
+++ b/uri/exid-types/FindAGrave-CemeteryId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FindAGrave.com
 
-documentation: https://support.findagrave.com/s/article/Cemetery-Search
+documentation:
+  - https://support.findagrave.com/s/article/Cemetery-Search
 
 ...

--- a/uri/exid-types/FindAGrave-CemeteryId.yaml
+++ b/uri/exid-types/FindAGrave-CemeteryId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FindAGrave Cemetery ID
+
+lang: en
+
+type: uri
+
+uri: https://www.findagrave.com/cemetery
+
+specification:
+  - FindAGrave Cemetery ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FindAGrave.com
+
+documentation: https://support.findagrave.com/s/article/Cemetery-Search
+
+...

--- a/uri/exid-types/FindAGrave-CemeteryId.yaml
+++ b/uri/exid-types/FindAGrave-CemeteryId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FindAGrave Cemetery ID
+label: 'FindAGrave Cemetery ID'
 
 lang: en
 

--- a/uri/exid-types/FindAGrave-MemorialId.yaml
+++ b/uri/exid-types/FindAGrave-MemorialId.yaml
@@ -6,7 +6,7 @@ lang: en
 
 type: uri
 
-uri: https://www.findagrave.com/memorial
+uri: https://www.findagrave.com/memorial/
 
 specification:
   - FindAGrave Memorial ID

--- a/uri/exid-types/FindAGrave-MemorialId.yaml
+++ b/uri/exid-types/FindAGrave-MemorialId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: FindAGrave Memorial ID
+
+lang: en
+
+type: uri
+
+uri: https://www.findagrave.com/memorial
+
+specification:
+  - FindAGrave Memorial ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: FindAGrave.com
+
+documentation: https://support.findagrave.com/s/article/Memorial-Search
+
+...

--- a/uri/exid-types/FindAGrave-MemorialId.yaml
+++ b/uri/exid-types/FindAGrave-MemorialId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: FindAGrave.com
 
-documentation: https://support.findagrave.com/s/article/Memorial-Search
+documentation:
+  - https://support.findagrave.com/s/article/Memorial-Search
 
 ...

--- a/uri/exid-types/FindAGrave-MemorialId.yaml
+++ b/uri/exid-types/FindAGrave-MemorialId.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: FindAGrave Memorial ID
+label: 'FindAGrave Memorial ID'
 
 lang: en
 

--- a/uri/exid-types/GOV-ID.yaml
+++ b/uri/exid-types/GOV-ID.yaml
@@ -25,6 +25,7 @@ contact: "gov-support@genealogy.net"
 
 change controller: CompGen
 
-documentation: https://wiki.genealogy.net/GOV
+documentation:
+  - https://wiki.genealogy.net/GOV
 
 ...

--- a/uri/exid-types/GOV-ID.yaml
+++ b/uri/exid-types/GOV-ID.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+label: GOV Historic Gazeteer ID
+
 lang: en
 
 type: uri
@@ -20,4 +22,9 @@ specification:
     The payload for EXID.TYPE is: http://gov.genealogy.net/
 
 contact: "gov-support@genealogy.net"
+
+change controller: CompGen
+
+documentation: https://wiki.genealogy.net/GOV
+
 ...

--- a/uri/exid-types/GOV-ID.yaml
+++ b/uri/exid-types/GOV-ID.yaml
@@ -1,15 +1,15 @@
 %YAML 1.2
 ---
-label: GOV Historic Gazeteer ID
+label: 'GOV Historic Gazeteer ID'
 
 lang: en
 
 type: uri
 
-uri: https://gedcom.io/exid-type/GOV-ID
+uri: https://gov.genealogy.net/
 
 specification:
-  - GOV Place ID
+  - GOV Historic Gazeteer Place ID
   - |
     This URI is defined for use as the https://gedcom.io/terms/v7/TYPE of an
     https://gedcom.io/terms/v7/EXID containing a GOV-ID as defined at
@@ -19,7 +19,7 @@ specification:
     is a location database maintained by volunteers from the association for
     computer genealogy (CompGen).
 
-    The payload for EXID.TYPE is: http://gov.genealogy.net/
+    The payload for EXID.TYPE is: https://gov.genealogy.net/
 
 contact: "gov-support@genealogy.net"
 

--- a/uri/exid-types/RFN.yaml
+++ b/uri/exid-types/RFN.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+label: RFN
+
 lang: en
 
 type: uri
@@ -36,5 +38,13 @@ specification:
     
         2 EXID xyz
         3 TYPE https://gedcom.io/terms/v7/RFN#123abc
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+fragment: Resource ID
+
+documentation: https://gedcom.io/migrate/#afn-rfn-rin
 
 ...

--- a/uri/exid-types/RFN.yaml
+++ b/uri/exid-types/RFN.yaml
@@ -45,6 +45,7 @@ change controller: FamilySearch
 
 fragment: Resource ID
 
-documentation: https://gedcom.io/migrate/#afn-rfn-rin
+documentation:
+  - https://gedcom.io/migrate/#afn-rfn-rin
 
 ...

--- a/uri/exid-types/RFN.yaml
+++ b/uri/exid-types/RFN.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: RFN
+label: 'Record File Number'
 
 lang: en
 
@@ -9,7 +9,7 @@ type: uri
 uri: https://gedcom.io/terms/v7/RFN
 
 specification:
-  - Record File Number
+  - Permanent Record ID
   - |
     This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
     GEDCOM 7.0 and beyond. It is intended for use as the 

--- a/uri/exid-types/RIN.yaml
+++ b/uri/exid-types/RIN.yaml
@@ -1,6 +1,6 @@
 %YAML 1.2
 ---
-label: RIN
+label: 'Record ID Number'
 
 lang: en
 
@@ -9,7 +9,7 @@ type: uri
 uri: https://gedcom.io/terms/v7/RIN
 
 specification:
-  - Record ID Number
+  - Automated Record ID
   - |
     This URI is defined to support conversion from GEDCOM 5.5.1 to FamilySearch
     GEDCOM 7.0 and beyond. It is intended for use as the

--- a/uri/exid-types/RIN.yaml
+++ b/uri/exid-types/RIN.yaml
@@ -42,8 +42,6 @@ specification:
 
 contact: GEDCOM@familysearch.org
 
-change controller: FamilySearch
-
 fragment: Source System
 
 documentation: https://gedcom.io/migrate/#afn-rfn-rin

--- a/uri/exid-types/RIN.yaml
+++ b/uri/exid-types/RIN.yaml
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+label: RIN
+
 lang: en
 
 type: uri
@@ -37,5 +39,13 @@ specification:
     
         2 EXID 123abc
         3 TYPE https://gedcom.io/terms/v7/RIN#XYZ
+
+contact: GEDCOM@familysearch.org
+
+change controller: FamilySearch
+
+fragment: Source System
+
+documentation: https://gedcom.io/migrate/#afn-rfn-rin
 
 ...

--- a/uri/exid-types/RIN.yaml
+++ b/uri/exid-types/RIN.yaml
@@ -44,6 +44,7 @@ contact: GEDCOM@familysearch.org
 
 fragment: Source System
 
-documentation: https://gedcom.io/migrate/#afn-rfn-rin
+documentation:
+  - https://gedcom.io/migrate/#afn-rfn-rin
 
 ...

--- a/uri/exid-types/WikiTree-PersonId.yaml
+++ b/uri/exid-types/WikiTree-PersonId.yaml
@@ -15,6 +15,7 @@ contact: GEDCOM@familysearch.org
 
 change controller: wikitree.com
 
-documentation: https://www.wikitree.com/wiki/Help:WikiTree_ID
+documentation:
+  - https://www.wikitree.com/wiki/Help:WikiTree_ID
 
 ...

--- a/uri/exid-types/WikiTree-PersonId.yaml
+++ b/uri/exid-types/WikiTree-PersonId.yaml
@@ -1,0 +1,20 @@
+%YAML 1.2
+---
+label: 'WikiTree Person ID'
+
+lang: en
+
+type: uri
+
+uri: https://www.wikitree.com/wiki/
+
+specification:
+  - WikiTree Person ID
+
+contact: GEDCOM@familysearch.org
+
+change controller: wikitree.com
+
+documentation: https://www.wikitree.com/wiki/Help:WikiTree_ID
+
+...


### PR DESCRIPTION
Copied data from https://github.com/FamilySearch/GEDCOM/blob/main/exid-types.json

In cases where data existed and there was a conflict, copied what was in exid-types.json even though it might be wrong, to make it obvious what the difference was.