### PR TITLE
Add Tag Extension structures

### DIFF
--- a/structure/_ATTR.yaml
+++ b/structure/_ATTR.yaml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://gedcom.io/terms/v7/_ATTR
+
+standard tag: _ATTR
+
+specification:
+  - Generic Attribute
+  - |
+    The _ATTR structure provides a generic mechanism for vendors to add
+    custom attributes to tags. The payload contains the attribute name,
+    and the required _VALUE substructure contains the attribute value.
+    
+    This allows software to extend tags with specific functionality
+    without requiring changes to the base specification.
+
+label: 'Attribute'
+
+payload: http://www.w3.org/2001/XMLSchema#string
+
+substructures:
+  "https://gedcom.io/terms/v7/_VALUE": "{1:1}"
+
+superstructures:
+  "https://gedcom.io/terms/v7/_TAG": "{0:M}"
+
+contact: "glamberson@gmail.com"
+...

--- a/structure/_COLOR.yaml
+++ b/structure/_COLOR.yaml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://gedcom.io/terms/v7/_COLOR
+
+standard tag: _COLOR
+
+specification:
+  - Color
+  - |
+    The _COLOR structure specifies a color for visual representation of a tag.
+    The color must be specified as a 6-digit hexadecimal value in the format
+    #RRGGBB, where RR is red, GG is green, and BB is blue. Values are 
+    case-insensitive.
+    
+    Examples: #FF0000 (red), #00FF00 (green), #0000FF (blue)
+
+label: 'Color'
+
+payload: http://www.w3.org/2001/XMLSchema#string
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v7/_TAG": "{0:1}"
+
+contact: "glamberson@gmail.com"
+...

--- a/structure/_TAG.yaml
+++ b/structure/_TAG.yaml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: record
+
+uri: https://gedcom.io/terms/v7/_TAG
+
+standard tag: _TAG
+
+specification:
+  - Tag Record
+  - |
+    A _TAG record represents an organizational tag that can be applied to
+    any record type for categorization purposes. Tags support optional
+    visual color coding and vendor-specific attributes through the 
+    generic _ATTR mechanism.
+    
+    Tags are first-class records that exist at the top level and are
+    referenced by other records using the _TAG substructure.
+
+label: 'Tag'
+
+payload: null
+
+substructures:
+  "https://gedcom.io/terms/v7/NAME": "{1:1}"
+  "https://gedcom.io/terms/v7/_COLOR": "{0:1}"
+  "https://gedcom.io/terms/v7/_ATTR": "{0:M}"
+  "https://gedcom.io/terms/v7/NOTE": "{0:M}"
+  "https://gedcom.io/terms/v7/SNOTE": "{0:M}"
+  "https://gedcom.io/terms/v7/CHAN": "{0:1}"
+
+superstructures: {}
+
+contact: "glamberson@gmail.com"
+...

--- a/structure/_TAG_ref.yaml
+++ b/structure/_TAG_ref.yaml
@@ -1,0 +1,46 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://gedcom.io/terms/v7/_TAG
+
+standard tag: _TAG
+
+specification:
+  - Tag Reference
+  - |
+    When used as a substructure, _TAG references a tag record to apply
+    that tag to the containing record. The payload is a pointer to a
+    _TAG record. Optional DATE and NOTE substructures can provide
+    context about when and why the tag was applied.
+
+label: 'Tag Reference'
+
+payload: https://gedcom.io/terms/v7/type-Pointer
+
+substructures:
+  "https://gedcom.io/terms/v7/DATE": "{0:1}"
+  "https://gedcom.io/terms/v7/NOTE": "{0:M}"
+
+superstructures:
+  "https://gedcom.io/terms/v7/record-INDI": "{0:M}"
+  "https://gedcom.io/terms/v7/record-FAM": "{0:M}"
+  "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
+  "https://gedcom.io/terms/v7/record-REPO": "{0:M}"
+  "https://gedcom.io/terms/v7/record-OBJE": "{0:M}"
+  "https://gedcom.io/terms/v7/record-NOTE": "{0:M}"
+  "https://gedcom.io/terms/v7/record-SNOTE": "{0:M}"
+  "https://gedcom.io/terms/v7/record-SUBM": "{0:M}"
+  "https://gedcom.io/terms/v7/EVEN": "{0:M}"
+  "https://gedcom.io/terms/v7/BIRT": "{0:M}"
+  "https://gedcom.io/terms/v7/DEAT": "{0:M}"
+  "https://gedcom.io/terms/v7/MARR": "{0:M}"
+  "https://gedcom.io/terms/v7/CENS": "{0:M}"
+  "https://gedcom.io/terms/v7/PLAC": "{0:M}"
+  "https://gedcom.io/terms/v7/NAME": "{0:M}"
+  "https://gedcom.io/terms/v7/ASSO": "{0:M}"
+
+contact: "glamberson@gmail.com"
+...

--- a/structure/_VALUE.yaml
+++ b/structure/_VALUE.yaml
@@ -1,0 +1,28 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://gedcom.io/terms/v7/_VALUE
+
+standard tag: _VALUE
+
+specification:
+  - Attribute Value
+  - |
+    The _VALUE structure contains the value for a generic attribute
+    defined by _ATTR. The value is a string that can contain any
+    vendor-specific data.
+
+label: 'Value'
+
+payload: http://www.w3.org/2001/XMLSchema#string
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v7/_ATTR": "{1:1}"
+
+contact: "glamberson@gmail.com"
+...


### PR DESCRIPTION
## Summary
This PR adds structures for the GEDCOM Tag Extension, which enables preservation of organizational tags commonly used in genealogy software.

## Extension Overview
- **Purpose**: Preserve user-defined tags with colors and vendor-specific attributes
- **Repository**: https://github.com/glamberson/gedcom-tags
- **Version**: 0.1.0
- **Contact**: glamberson@gmail.com

## Structures Added
- `_TAG` - Tag record type for defining reusable organizational markers
- `_TAG` (ref) - Substructure for applying tags to records  
- `_COLOR` - Optional color specification (6-digit hex)
- `_ATTR` - Generic vendor attribute mechanism
- `_VALUE` - Value for generic attributes

## Key Features
1. Universal application to any record type
2. Optional visual color coding  
3. Vendor extensibility through _ATTR
4. Round-trip preservation of tag data

## Use Case
Modern genealogy software universally implements tagging/categorization systems, but these are lost during GEDCOM export. This extension preserves:
- Research status tags (ToDo, InProgress, Complete)
- DNA match markers
- Visual color coding
- Software-specific tag attributes

## Documentation
Full specification and examples available at: https://github.com/glamberson/gedcom-tags

## Testing
Example GEDCOM files demonstrating usage are included in the repository:
- [basic.ged](https://github.com/glamberson/gedcom-tags/blob/main/examples/basic.ged) - Simple tag usage
- [advanced.ged](https://github.com/glamberson/gedcom-tags/blob/main/examples/advanced.ged) - Vendor attributes
- [gramps-compatibility.ged](https://github.com/glamberson/gedcom-tags/blob/main/examples/gramps-compatibility.ged) - Hierarchical tags