### PR TITLE
Add prerelease to _DATE and _SOUR extensions

### DIFF
--- a/structure/extension/_DATE.yaml
+++ b/structure/extension/_DATE.yaml
@@ -34,4 +34,6 @@ substructures:
 
 superstructures:
   "https://gedcom.io/terms/v7/REPO": "{0:M}"
+
+prerelease: true
 ...

--- a/structure/extension/_SOUR.yaml
+++ b/structure/extension/_SOUR.yaml
@@ -31,4 +31,6 @@ substructures:
 superstructures:
   "https://gedcom.io/terms/v7/PAGE": "{0:M}"
   "https://gedcom.io/terms/v7/record-SOUR": "{0:M}"
+
+prerelease: true
 ...


### PR DESCRIPTION
https://github.com/FamilySearch/GEDCOM.io/pull/283 recently added `prerelease` to the schema.  This PR adds that for the gedcom-citations extensions.