### PR TITLE
Add GEDCOM Extended ASSO structures

### DIFF
--- a/structure/extension/_CONF.yaml
+++ b/structure/extension/_CONF.yaml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/glamberson/gedcom-extended-ASSO/_CONF
+
+extension tags: [ _CONF ]
+
+specification:
+  - Association Confidence
+  - |
+    Indicates the confidence level in the association assertion.
+    Uses an integer scale from 0 to 4:
+    
+    0 = Unreliable evidence or estimated data
+    1 = Questionable reliability of evidence  
+    2 = Secondary evidence, data probably reliable
+    3 = Direct source, primary evidence, data considered reliable
+    4 = Well-supported conclusion from primary evidence
+    
+    This scale matches GEDCOM 7's QUAY (quality) values for consistency.
+    
+    Examples:
+    - 4: Business partnership documented in legal records
+    - 3: Godparent relationship from church baptism record
+    - 1: Possible sibling based on census proximity and ages
+    - 0: Family legend of relationship, no documentation
+
+label: 'Confidence Level'
+
+payload: https://gedcom.io/terms/v7/type-Integer
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v7/ASSO": "{0:1}"
+
+contact: lamberson@yahoo.com
+...

--- a/structure/extension/_END.yaml
+++ b/structure/extension/_END.yaml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/glamberson/gedcom-extended-ASSO/_END
+
+extension tags: [ _END ]
+
+specification:
+  - Association End Date
+  - |
+    The date when an association ended. Uses standard GEDCOM 7 date format,
+    allowing for exact dates, date ranges, and approximate dates.
+    
+    Examples:
+    - "15 MAY 1868" - Exact date ward reached majority
+    - "JUN 1867" - Month business partnership dissolved
+    - "8 MAY 1945" - End of military service (VE Day)
+    - "BEF 1960" - Friendship ended sometime before this date
+
+label: 'End Date'
+
+payload: https://gedcom.io/terms/v7/type-Date
+
+substructures:
+  "https://gedcom.io/terms/v7/PHRASE": "{0:1}"
+  "https://gedcom.io/terms/v7/TIME": "{0:1}"
+
+superstructures:
+  "https://github.com/glamberson/gedcom-extended-ASSO/_PERIOD": "{0:1}"
+
+contact: lamberson@yahoo.com
+...

--- a/structure/extension/_PERIOD.yaml
+++ b/structure/extension/_PERIOD.yaml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/glamberson/gedcom-extended-ASSO/_PERIOD
+
+extension tags: [ _PERIOD ]
+
+specification:
+  - Association Time Period
+  - |
+    Container structure for defining the time boundaries of an association.
+    Allows specification of when an association began and/or ended.
+    
+    Either START or END may be omitted if unknown. If both are omitted,
+    the PERIOD structure should not be used.
+    
+    Examples:
+    - Godparent relationship: START at baptism, END at ward's majority
+    - Employment: START date of hire, END date of termination
+    - Military service: START at enlistment, END at discharge
+    - Friendship: May have only START if still ongoing
+
+label: 'Association Time Period'
+
+payload: null
+
+substructures:
+  "https://github.com/glamberson/gedcom-extended-ASSO/_START": "{0:1}"
+  "https://github.com/glamberson/gedcom-extended-ASSO/_END": "{0:1}"
+
+superstructures:
+  "https://gedcom.io/terms/v7/ASSO": "{0:1}"
+
+contact: lamberson@yahoo.com
+...

--- a/structure/extension/_PRIV.yaml
+++ b/structure/extension/_PRIV.yaml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/glamberson/gedcom-extended-ASSO/_PRIV
+
+extension tags: [ _PRIV ]
+
+specification:
+  - Association Privacy Flag
+  - |
+    Indicates whether this specific association should be treated as private,
+    independent of the privacy settings of the individuals involved.
+    
+    Use cases:
+    - Sensitive professional relationships
+    - Confidential informant relationships
+    - Medical or legal associations
+    - Any relationship where disclosure could be harmful
+    
+    Applications should respect this flag by:
+    - Excluding private associations from public reports
+    - Requiring additional authentication to view
+    - Masking or redacting in exports
+
+label: 'Privacy Flag'
+
+payload: Y|<NULL>
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v7/ASSO": "{0:1}"
+
+contact: lamberson@yahoo.com
+...

--- a/structure/extension/_START.yaml
+++ b/structure/extension/_START.yaml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/glamberson/gedcom-extended-ASSO/_START
+
+extension tags: [ _START ]
+
+specification:
+  - Association Start Date
+  - |
+    The date when an association began. Uses standard GEDCOM 7 date format,
+    allowing for exact dates, date ranges, and approximate dates.
+    
+    Examples:
+    - "15 MAY 1850" - Exact date of baptism for godparent relationship
+    - "1845" - Year-only for business partnership
+    - "ABT 1920" - Approximate date for friendship
+    - "BEF 1863" - Known to have started before a certain date
+
+label: 'Start Date'
+
+payload: https://gedcom.io/terms/v7/type-Date
+
+substructures:
+  "https://gedcom.io/terms/v7/PHRASE": "{0:1}"
+  "https://gedcom.io/terms/v7/TIME": "{0:1}"
+
+superstructures:
+  "https://github.com/glamberson/gedcom-extended-ASSO/_PERIOD": "{0:1}"
+
+contact: lamberson@yahoo.com
+...

--- a/structure/extension/_TYPE.yaml
+++ b/structure/extension/_TYPE.yaml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/glamberson/gedcom-extended-ASSO/_TYPE
+
+extension tags: [ _TYPE ]
+
+specification:
+  - Association Type
+  - |
+    Specifies the type of association or relationship beyond the standard ROLE.
+    This provides more specific categorization of the relationship between
+    two individuals.
+    
+    Unlike ROLE which uses a controlled vocabulary, TYPE allows free-text
+    description to accommodate various relationship types across cultures
+    and time periods.
+    
+    Examples:
+    - "Godparent" (with ROLE "Godfather" or "Godmother")
+    - "Business Partnership" (with ROLE "Business Partner")
+    - "Military Service" (with ROLE "Fellow Soldier")
+    - "Childhood Friend" (with ROLE "Friend")
+    - "Neighbor" (with ROLE "Neighbor")
+
+label: 'Association Type'
+
+payload: https://gedcom.io/terms/v7/type-Text
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v7/ASSO": "{0:1}"
+
+contact: lamberson@yahoo.com
+...


### PR DESCRIPTION
## Summary

This PR adds extension structures to enhance the standard GEDCOM 7 ASSO (association) tag with additional capabilities while maintaining backward compatibility.

## Extension Features

The gedcom-extended-ASSO extension adds six new substructures to ASSO:

1. **_TYPE** - Specifies the type of association beyond the standard ROLE
2. **_PERIOD** - Container for time boundaries of the association
3. **_START** - When the association began  
4. **_END** - When the association ended
5. **_CONF** - Confidence level (0-4 scale matching GEDCOM 7's QUAY)
6. **_PRIV** - Privacy flag for sensitive associations

## Example Usage

```gedcom
0 @I1@ INDI
1 NAME John /Smith/
1 ASSO @I2@
2 ROLE Business Partner
2 _TYPE General Partnership
2 _PERIOD
3 _START 1845
3 _END JUN 1867
2 _CONF 4
2 NOTE Wilson & Associates Mercantile
```

## Backward Compatibility

Applications that don't support this extension will:
- See and preserve the standard ASSO structure
- Ignore all extension tags
- Maintain data integrity on import/export

## Documentation

- Full specification: https://github.com/glamberson/gedcom-extended-ASSO
- Examples: https://github.com/glamberson/gedcom-extended-ASSO/tree/master/examples

## Validation

All YAML files have been validated using the registry validator.

Contact: Greg Lamberson <lamberson@yahoo.com>