### PR TITLE
Add Ancestry PUBL.{DATE,PLAC} nonconformant extensions

### DIFF
--- a/structure/extension/Ancestry_PUBL_DATE.yaml
+++ b/structure/extension/Ancestry_PUBL_DATE.yaml
@@ -1,0 +1,30 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/FamilySearch/GEDCOM-registries/blob/main/structure/extension/Ancestry_PUBL_DATE.yaml
+
+nonconformant tags:
+  - DATE
+
+specification:
+  - The publication date.
+
+label: 'Publication Date'
+
+payload: https://gedcom.io/terms/v5.5.1/type-DATE_EXACT
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v5.5.1/PUBL": "{0:1}"
+
+change controller: Ancestry.com
+
+used by:
+  - Ancestry.com Family Trees
+
+contact: "https://gedcom.io/community/"
+...

--- a/structure/extension/Ancestry_PUBL_PLAC.yaml
+++ b/structure/extension/Ancestry_PUBL_PLAC.yaml
@@ -1,0 +1,30 @@
+%YAML 1.2
+---
+lang: en-US
+
+type: structure
+
+uri: https://github.com/FamilySearch/GEDCOM-registries/blob/main/structure/extension/Ancestry_PUBL_PLAC.yaml
+
+nonconformant tags:
+  - PLAC
+
+specification:
+  - The publication place.
+
+label: 'Publication Place'
+
+payload: https://gedcom.io/terms/v5.5.1/type-PLACE_NAME
+
+substructures: {}
+
+superstructures:
+  "https://gedcom.io/terms/v5.5.1/PUBL": "{0:1}"
+
+change controller: Ancestry.com
+
+used by:
+  - Ancestry.com Family Trees
+
+contact: "https://gedcom.io/community/"
+...


### PR DESCRIPTION
Reported at https://github.com/iand/gedcom#ancestry

I confirmed by exporting a GEDCOM myself, and see this for example in the GEDCOM 5.5.1 export:

```
0 @S_1095918390@ SOUR
1 TITL Connecticut, Church Record Abstracts, 1630-1920
1 AUTH Ancestry.com
1 PUBL
2 DATE 2013
2 PLAC Provo, UT, USA
1 _APID 1,3032::0
1 REPO @R_2146200035@
```

This PR is an experiment to test a process for third-party registration.